### PR TITLE
HiKey: reserve top 16MB for OPTEE

### DIFF
--- a/HisiPkg/HiKeyPkg/HiKey.dsc
+++ b/HisiPkg/HiKeyPkg/HiKey.dsc
@@ -109,7 +109,7 @@
 
   # System Memory (1GB)
   gArmTokenSpaceGuid.PcdSystemMemoryBase|0x00000000
-  gArmTokenSpaceGuid.PcdSystemMemorySize|0x40000000
+  gArmTokenSpaceGuid.PcdSystemMemorySize|0x3F000000
 
   # HiKey Dual-Cluster profile
   gArmPlatformTokenSpaceGuid.PcdCoreCount|8

--- a/HisiPkg/HiKeyPkg/HiKey.fdf
+++ b/HisiPkg/HiKeyPkg/HiKey.fdf
@@ -26,7 +26,7 @@
 ################################################################################
 
 [FD.BL33_AP_UEFI]
-BaseAddress   = 0x37000000|gArmTokenSpaceGuid.PcdFdBaseAddress  # The base address of the Firmware in NOR Flash.
+BaseAddress   = 0x35000000|gArmTokenSpaceGuid.PcdFdBaseAddress  # The base address of the Firmware in NOR Flash.
 Size          = 0x000F0000|gArmTokenSpaceGuid.PcdFdSize         # The size in bytes of the FLASH Device
 ErasePolarity = 1
 


### PR DESCRIPTION
Reserve top 16MB memory (0x3F00_0000~0x3FFF_FFFC) in DRAM for OPTEE.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
