### PR TITLE
hikey: reserve additional 16MB for OPTEE

### DIFF
--- a/HisiPkg/HiKeyPkg/HiKey.dsc
+++ b/HisiPkg/HiKeyPkg/HiKey.dsc
@@ -109,7 +109,7 @@
 
   # System Memory (1GB)
   gArmTokenSpaceGuid.PcdSystemMemoryBase|0x00000000
-  gArmTokenSpaceGuid.PcdSystemMemorySize|0x3F000000
+  gArmTokenSpaceGuid.PcdSystemMemorySize|0x3E000000
 
   # HiKey Dual-Cluster profile
   gArmPlatformTokenSpaceGuid.PcdCoreCount|8


### PR DESCRIPTION
0x3E00_0000-0x3EFF_FFFF: (normal world) for OPTEE.
0x3F00_0000-0x3FFF_FFFF: (secure world) for OPTEE.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
