### PR TITLE
ArmVExpressFastBoot: Add support for sparse Images

### DIFF
--- a/EmbeddedPkg/Include/Protocol/AndroidFastbootPlatform.h
+++ b/EmbeddedPkg/Include/Protocol/AndroidFastbootPlatform.h
@@ -142,4 +142,30 @@ typedef struct _FASTBOOT_PLATFORM_PROTOCOL {
   FASTBOOT_PLATFORM_OEM_COMMAND   DoOemCommand;
 } FASTBOOT_PLATFORM_PROTOCOL;
 
+/* See sparse_format.h in AOSP  */
+#define SPARSE_HEADER_MAGIC 0xed26ff3a
+#define CHUNK_TYPE_RAW      0xCAC1
+#define CHUNK_TYPE_FILL     0xCAC2
+#define CHUNK_TYPE_DONT_CARE    0xCAC3
+#define CHUNK_TYPE_CRC32    0xCAC4
+
+typedef struct _SPARSE_HEADER {
+  UINT32    Magic;
+  UINT16    MajorVersion;
+  UINT16    MinorVersion;
+  UINT16    FileHeaderSize;
+  UINT16    ChunkHeaderSize;
+  UINT32    BlockSize;
+  UINT32    TotalBlocks;
+  UINT32    TotalChunks;
+  UINT32    ImageChecksum;
+} SPARSE_HEADER;
+
+typedef struct _CHUNK_HEADER {
+  UINT16    ChunkType;
+  UINT16    Reserved1;
+  UINT32    ChunkSize;
+  UINT32    TotalSize;
+} CHUNK_HEADER;
+
 #endif


### PR DESCRIPTION
Add support for current Fastboot Sparse images. Tested to be able
to flash both a a small image (60MB) And a large 1.5GB image. The
code in it's current form doesn't do many checks, so no defences
against corrupt images.

ArmVExpressFastBoot is obviously the wrong place to implement this,
Implementing it correctly in AndroidFastbootApp requires changing
FASTBOOT_PLATFORM_FLASH with a "offset" parameter.

Cc: Zhangfei Gao zhangfei.gao@linaro.org
Cc: Olivier Martin olivier.martin@arm.com
Signed-off-by: Riku Voipio riku.voipio@linaro.org
