### PR TITLE
HiKey: fastboot: fix negative size for partition

### DIFF
--- a/HisiPkg/HiKeyPkg/Drivers/HiKeyFastbootDxe/HiKeyFastboot.c
+++ b/HisiPkg/HiKeyPkg/Drivers/HiKeyFastbootDxe/HiKeyFastboot.c
@@ -397,7 +397,7 @@ HiKeyFastbootPlatformFlashPartition (
   PartitionSize = (BlockIo->Media->LastBlock + 1) * BlockIo->Media->BlockSize;
   if (PartitionSize < Size) {
     DEBUG ((EFI_D_ERROR, "Partition not big enough.\n"));
-    DEBUG ((EFI_D_ERROR, "Partition Size:\t%d\nImage Size:\t%d\n", PartitionSize, Size));
+    DEBUG ((EFI_D_ERROR, "Partition Size:\t%ld\nImage Size:\t%ld\n", PartitionSize, Size));
 
     return EFI_VOLUME_FULL;
   }


### PR DESCRIPTION
If partition size is large, it'll be printed as negative value.
Since print function treats it as 32-bit value, replace "%d" with
"%ld" to fix this issue.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
