### PR TITLE
HiKeyPkg: bootmenu: tune bootorder index

### DIFF
--- a/HisiPkg/HiKeyPkg/Drivers/HiKeyFastbootDxe/HiKeyFastboot.c
+++ b/HisiPkg/HiKeyPkg/Drivers/HiKeyFastbootDxe/HiKeyFastboot.c
@@ -656,7 +656,8 @@ HiKeyFastbootPlatformOemCommand (
       else
         break;
     }
-    Data = AsciiStrDecimalToUintn (Command + Index);
+    // HiKeyBootNext is counted from 0, bootorder is counted from 1.
+    Data = AsciiStrDecimalToUintn (Command + Index) - 1;
 
     VariableSize = sizeof (UINT16);
     Status = gRT->GetVariable (


### PR DESCRIPTION
Count bootorder index from 1 instead. It's used to keep the same index value
in the UEFI boot menu.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
