### PR TITLE
HiKeyPkg: update PcdTimerPeriod

### DIFF
--- a/HisiPkg/HiKeyPkg/HiKey.dsc
+++ b/HisiPkg/HiKeyPkg/HiKey.dsc
@@ -324,6 +324,7 @@
   #
   gArmTokenSpaceGuid.PcdArmArchTimerFreqInHz|1200000
   gEmbeddedTokenSpaceGuid.PcdMetronomeTickPeriod|1000
+  gEmbeddedTokenSpaceGuid.PcdTimerPeriod|10000
 
   #
   # DW MMC/SD card controller


### PR DESCRIPTION
Set PcdTimerPeriod to 10,000 (1 millisecond). Since grub needs
a timer notification with 1 millisecond, we need to set
PcdTimerPeriod from 100,000 to 10,000. Otherwise, all timer
notification in grub is 10 milliseconds.

100,000 \* 100ns = 10ms
10,000 \* 100ns = 1ms

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
