### PR TITLE
Revert "EmbeddedPkg: DwMmc: remove delay for sending cmd"

### DIFF
--- a/EmbeddedPkg/Drivers/DwMmcDxe/DwMmcDxe.c
+++ b/EmbeddedPkg/Drivers/DwMmcDxe/DwMmcDxe.c
@@ -14,7 +14,6 @@
 
 **/
 
-#include <Library/ArmLib.h>
 #include <Library/BaseMemoryLib.h>
 #include <Library/CacheMaintenanceLib.h>
 #include <Library/DebugLib.h>
@@ -320,14 +319,11 @@ SendCommand (
             DWMMC_INT_RCRC | DWMMC_INT_RE;
   ErrMask |= DWMMC_INT_DCRC | DWMMC_INT_DRT | DWMMC_INT_SBE;
   do {
-    ArmInstructionSynchronizationBarrier ();
-    ArmDataSyncronizationBarrier ();
+    MicroSecondDelay(500);
     Data = MmioRead32 (DWMMC_RINTSTS);
 
-    if (Data & ErrMask) {
-      DEBUG ((EFI_D_ERROR, "%a, Error RINTSTS value:0x%x\n", __func__, Data));
+    if (Data & ErrMask)
       return EFI_DEVICE_ERROR;
-    }
     if (Data & DWMMC_INT_DTO)	// Transfer Done
       break;
   } while (!(Data & DWMMC_INT_CMD_DONE));


### PR DESCRIPTION
This reverts commit bfec04f8de3fee34bb259ceae94f99766edb7bfc.

After applying this patch, sometimes fail to access eMMC device. Revert it first.
