### PR TITLE
HiKey: make PcdSerialRegisterBase configurable with a macro

### DIFF
--- a/HisiPkg/HiKeyPkg/HiKey.dsc
+++ b/HisiPkg/HiKeyPkg/HiKey.dsc
@@ -281,7 +281,8 @@
   #
 
   ## PL011 - Serial Terminal
-  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0xF7113000
+  DEFINE SERIAL_BASE = 0xF7113000 # UART3
+  gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|$(SERIAL_BASE)
   gEfiMdePkgTokenSpaceGuid.PcdUartDefaultBaudRate|115200
   gArmPlatformTokenSpaceGuid.PL011UartInteger|10
   gArmPlatformTokenSpaceGuid.PL011UartFractional|26


### PR DESCRIPTION
This allows to externally select which UART is used. For instance
to enable UART0, just give its base address on the make command line:

  make ... EDK2_MACROS="-DSERIAL_BASE=0xF8015000"

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
