### PR TITLE
HiKeyPkg: fix reference on ArmPlatformSysConfigLib

### DIFF
--- a/HisiPkg/HiKeyPkg/HiKey.dsc
+++ b/HisiPkg/HiKeyPkg/HiKey.dsc
@@ -43,7 +43,7 @@
 
   ArmPlatformLib|HisiPkg/HiKeyPkg/Library/HiKeyLib/HiKeyLib.inf
   ArmPlatformStackLib|ArmPlatformPkg/Library/ArmPlatformStackLib/ArmPlatformStackLib.inf
-  ArmPlatformSysConfigLib|ArmPlatformPkg/ArmVExpressPkg/Library/ArmVExpressSysConfigLib/ArmVExpressSysConfigLib.inf
+  ArmPlatformSysConfigLib|ArmPlatformPkg/Library/ArmPlatformSysConfigLibNull/ArmPlatformSysConfigLibNull.inf
 
   BaseLib|MdePkg/Library/BaseLib/BaseLib.inf
   BaseMemoryLib|ArmPkg/Library/BaseMemoryLibStm/BaseMemoryLibStm.inf


### PR DESCRIPTION
Since it's hikey, not arm vexpress platform. We should refer to
ArmVExpressSysConfigLib. Use ArmPlatformSysConfigLibNull instead.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
