### PR TITLE
HiKeyPkg: SN: load SN from emmc

### DIFF
--- a/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/HiKeyDxe.c
+++ b/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/HiKeyDxe.c
@@ -15,6 +15,7 @@
 
 #include <Library/BaseMemoryLib.h>
 #include <Library/BdsLib.h>
+#include <Library/CacheMaintenanceLib.h>
 #include <Library/DevicePathLib.h>
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
@@ -23,40 +24,112 @@
 
 #include <Guid/ArmGlobalVariableHob.h>
 
+#include <Protocol/BlockIo.h>
+
 #include "HiKeyDxeInternal.h"
 
 #define SERIAL_NUMBER_LENGTH        16
+#define SERIAL_NUMBER_LBA           1024
+#define SERIAL_NUMBER_BLOCK_SIZE    512
+#define RANDOM_MAGIC                0x9a4dbeaf
+
+struct RandomSerialNo {
+  UINTN              Magic;
+  UINTN              Data;
+  CHAR8              SerialNo[32];
+};
 
 STATIC
-VOID
+UINTN
 EFIAPI
 HiKeyInitSerialNo (
   IN   VOID
   )
 {
-  EFI_STATUS           Status;
-  UINTN                VariableSize;
-  CHAR16               DefaultSerialNo[] = L"0123456789abcdef";
+  EFI_STATUS                      Status;
+  UINTN                           VariableSize;
+  EFI_DEVICE_PATH_PROTOCOL        *BlockDevicePath;
+  EFI_BLOCK_IO_PROTOCOL           *BlockIoProtocol;
+  EFI_HANDLE                      Handle;
+  VOID                            *DataPtr;
+  struct RandomSerialNo           *Random;
+  CHAR16                          DefaultSerialNo[] = L"0123456789abcdef";
+  CHAR16                          SerialNoUnicode[32], DataUnicode[32];
 
-  VariableSize = SERIAL_NUMBER_LENGTH * sizeof (CHAR16);
-  Status = gRT->GetVariable (
-                  (CHAR16 *)L"SerialNo",
-                  &gArmGlobalVariableGuid,
-                  NULL,
-                  &VariableSize,
-                  &DefaultSerialNo
-                  );
-  if (Status == EFI_NOT_FOUND) {
-    Status = gRT->SetVariable (
-                    (CHAR16*)L"SerialNo",
-                    &gArmGlobalVariableGuid,
-                    EFI_VARIABLE_NON_VOLATILE       |
-                    EFI_VARIABLE_BOOTSERVICE_ACCESS |
-                    EFI_VARIABLE_RUNTIME_ACCESS,
-                    VariableSize,
-                    DefaultSerialNo
-                    );
+  BlockDevicePath = ConvertTextToDevicePath ((CHAR16*)FixedPcdGetPtr (PcdAndroidFastbootNvmDevicePath));
+  Status = gBS->LocateDevicePath (&gEfiBlockIoProtocolGuid, &BlockDevicePath, &Handle);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((EFI_D_ERROR, "Warning: Couldn't locate block device (status: %r)\n", Status));
+    return EFI_INVALID_PARAMETER;
   }
+  Status = gBS->OpenProtocol (
+		      Handle,
+                      &gEfiBlockIoProtocolGuid,
+		      (VOID **) &BlockIoProtocol,
+                      gImageHandle,
+                      NULL,
+                      EFI_OPEN_PROTOCOL_GET_PROTOCOL
+                      );
+  if (EFI_ERROR (Status)) {
+    DEBUG ((EFI_D_ERROR, "Warning: Couldn't open block device (status: %r)\n", Status));
+    return EFI_DEVICE_ERROR;
+  }
+  DataPtr = AllocateZeroPool (SERIAL_NUMBER_BLOCK_SIZE);
+  WriteBackDataCacheRange (DataPtr, SERIAL_NUMBER_BLOCK_SIZE);
+  Status = BlockIoProtocol->ReadBlocks (BlockIoProtocol, BlockIoProtocol->Media->MediaId,
+                                        SERIAL_NUMBER_LBA, SERIAL_NUMBER_BLOCK_SIZE,
+                                        DataPtr);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((EFI_D_ERROR, "Warning: failed on reading blocks.\n"));
+    goto exit;
+  }
+  InvalidateDataCacheRange (DataPtr, SERIAL_NUMBER_BLOCK_SIZE);
+  Random = (struct RandomSerialNo *)DataPtr;
+  if (Random->Magic != RANDOM_MAGIC) {
+    VariableSize = SERIAL_NUMBER_LENGTH * sizeof (CHAR16);
+    Status = gRT->GetVariable (
+                    (CHAR16 *)L"SerialNo",
+                    &gArmGlobalVariableGuid,
+                    NULL,
+                    &VariableSize,
+                    &DefaultSerialNo
+                    );
+    if (Status == EFI_NOT_FOUND) {
+      Status = gRT->SetVariable (
+                      (CHAR16*)L"SerialNo",
+                      &gArmGlobalVariableGuid,
+                      EFI_VARIABLE_NON_VOLATILE       |
+                      EFI_VARIABLE_BOOTSERVICE_ACCESS |
+                      EFI_VARIABLE_RUNTIME_ACCESS,
+                      VariableSize,
+                      DefaultSerialNo
+                      );
+    }
+  } else {
+    AsciiStrToUnicodeStr (Random->SerialNo, SerialNoUnicode);
+    VariableSize = SERIAL_NUMBER_LENGTH * sizeof (CHAR16);
+    Status = gRT->GetVariable (
+                    (CHAR16 *)L"SerialNo",
+                    &gArmGlobalVariableGuid,
+                    NULL,
+                    &VariableSize,
+                    &DataUnicode
+                    );
+    if ((Status == EFI_NOT_FOUND) || StrCmp (DataUnicode, SerialNoUnicode)) {
+      Status = gRT->SetVariable (
+                      (CHAR16*)L"SerialNo",
+                      &gArmGlobalVariableGuid,
+                      EFI_VARIABLE_NON_VOLATILE       |
+                      EFI_VARIABLE_BOOTSERVICE_ACCESS |
+                      EFI_VARIABLE_RUNTIME_ACCESS,
+                      VariableSize,
+                      SerialNoUnicode
+                      );
+    }
+  }
+exit:
+  FreePool (DataPtr);
+  return Status;
 }
 
 STATIC

--- a/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/HiKeyDxe.inf
+++ b/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/HiKeyDxe.inf
@@ -30,10 +30,12 @@
   ArmPlatformPkg/ArmPlatformPkg.dec
   EmbeddedPkg/EmbeddedPkg.dec
   MdePkg/MdePkg.dec
+  HisiPkg/HisiPlatformPkg.dec
 
 [LibraryClasses]
   BaseMemoryLib
   BdsLib
+  CacheMaintenanceLib
   DebugLib
   DxeServicesTableLib
   FdtLib
@@ -64,8 +66,8 @@
 [FixedPcd]
   gArmTokenSpaceGuid.PcdSystemMemoryBase
   gArmTokenSpaceGuid.PcdSystemMemorySize
-
   gArmPlatformTokenSpaceGuid.PcdFdtDevicePath
+  gHwTokenSpaceGuid.PcdAndroidFastbootNvmDevicePath
 
 [Depex]
   TRUE


### PR DESCRIPTION
Since ATF will store random serial number in eMMC, load & use it
in UEFI now.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
