### PR TITLE
HiKeyPkg: reset i2c2 controller

### DIFF
--- a/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/HiKeyDxe.c
+++ b/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/HiKeyDxe.c
@@ -175,6 +175,7 @@ HiKeyEntryPoint (
 
   HiKeyInitSerialNo ();
   HiKeyInitBootDevice ();
+  HiKeyInitPeripherals ();
 
   // Try to install the Flat Device Tree (FDT). This function actually installs the
   // UEFI Driver Binding Protocol.

--- a/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/HiKeyDxe.inf
+++ b/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/HiKeyDxe.inf
@@ -22,6 +22,7 @@
 
 [Sources.common]
   HiKeyDxe.c
+  InitPeripherals.c
   InstallFdt.c
   InstallBootMenu.c
 

--- a/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/InitPeripherals.c
+++ b/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/InitPeripherals.c
@@ -13,30 +13,22 @@
 *
 **/
 
-#ifndef __HIKEY_DXE_INTERNAL_H__
-#define __HIKEY_DXE_INTERNAL_H__
+#include <Library/IoLib.h>
 
-#include <Uefi.h>
+#include "Hi6220RegsPeri.h"
 
-#include <Library/DebugLib.h>
-#include <Library/DxeServicesTableLib.h>
-#include <Library/UefiBootServicesTableLib.h>
-
-#define BOOT_DEVICE_LENGTH       16
-
-EFI_STATUS
-HiKeyFdtInstall (
-  IN EFI_HANDLE                            ImageHandle
-  );
-
-EFI_STATUS
-HiKeyBootMenuInstall (
-  IN VOID
-  );
-
-EFI_STATUS
+VOID
+EFIAPI
 HiKeyInitPeripherals (
   IN VOID
-  );
+  )
+{
+  UINT32     Data;
 
-#endif // __HIKEY_DXE_INTERNAL_H__
+  /* make I2C2 out of reset */
+  MmioWrite32 (SC_PERIPH_RSTDIS3, PERIPH_RST3_I2C2);
+
+  do {
+    Data = MmioRead32 (SC_PERIPH_RSTSTAT3);
+  } while (Data & PERIPH_RST3_I2C2);
+}


### PR DESCRIPTION
Since i2c controller is in reset mode after system reset, i2c controller
can't work well in linux kernel. So release it from reset mode in UEFI.

Signed-off-by: Haojian Zhuang haojian.zhuang@gmail.com
