### PR TITLE
HiKeyPkg: fix checking error on 1GB version

### DIFF
--- a/HisiPkg/HiKeyPkg/Library/HiKeyLib/HiKeyMem.c
+++ b/HisiPkg/HiKeyPkg/Library/HiKeyLib/HiKeyMem.c
@@ -125,7 +125,7 @@ ArmPlatformGetVirtualMemoryMap (
   }
 
   AdditionalMemorySize = MemorySize - PcdGet64 (PcdSystemMemorySize);
-  if (AdditionalMemorySize > 0) {
+  if (AdditionalMemorySize >= SIZE_1GB) {
     // Declared the additional memory
     ResourceAttributes =
         EFI_RESOURCE_ATTRIBUTE_PRESENT |
@@ -170,7 +170,7 @@ ArmPlatformGetVirtualMemoryMap (
   VirtualMemoryTable[Index].Length          = PcdGet64 (PcdSystemMemorySize);
   VirtualMemoryTable[Index].Attributes      = CacheAttributes;
 
-  if (AdditionalMemorySize > 0) {
+  if (AdditionalMemorySize >= SIZE_1GB) {
     VirtualMemoryTable[++Index].PhysicalBase = HIKEY_EXTRA_SYSTEM_MEMORY_BASE;
     VirtualMemoryTable[Index].VirtualBase    = HIKEY_EXTRA_SYSTEM_MEMORY_BASE;
     VirtualMemoryTable[Index].Length         = HIKEY_EXTRA_SYSTEM_MEMORY_SIZE;


### PR DESCRIPTION
On 1GB version board, PcdSystemMemorySize is set as 0x3E00_0000,
not 0x4000_0000. So the checking on AdditionalSystemMemorySize
should be much larger. Now check it with SIZE_1GB instead.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
