### PR TITLE
[RFC] linaro-edk2: Enable "adb reboot bootloader" support

### DIFF
--- a/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/InstallBootMenu.c
+++ b/HisiPkg/HiKeyPkg/Drivers/HiKeyDxe/InstallBootMenu.c
@@ -375,6 +375,31 @@ HiKeyTestLed (
   }
 }
 
+
+#define REBOOT_REASON_ADDR		0x05F01000
+#define REBOOT_REASON_BOOTLOADER	0x77665500
+#define REBOOT_REASON_NONE		0x77665501
+STATIC
+VOID
+EFIAPI
+HiKeyDetectRebootReason (
+  IN     VOID
+  )
+{
+   UINT32 *addr = (UINT32*)REBOOT_REASON_ADDR;
+   UINT32  val;
+
+   val = *addr;
+   /* Check to see if "reboot booloader" was specified */
+   if (val == REBOOT_REASON_BOOTLOADER) {
+     mBootIndex = 0;
+   }
+   /* Write NONE to the reason address to clear the state */
+   *addr = REBOOT_REASON_NONE;
+
+   return;
+}
+
 STATIC
 VOID
 EFIAPI
@@ -540,6 +565,7 @@ HiKeyOnEndOfDxe (
   }
 
   HiKeyDetectJumper ();
+  HiKeyDetectRebootReason ();
 
   // Check boot device.
   // If boot device is eMMC, it's always higher priority.

--- a/HisiPkg/HiKeyPkg/Library/HiKeyLib/HiKeyMem.c
+++ b/HisiPkg/HiKeyPkg/Library/HiKeyLib/HiKeyMem.c
@@ -37,6 +37,7 @@ STATIC struct HiKeyReservedMemory {
   EFI_PHYSICAL_ADDRESS         Size;
 } HiKeyReservedMemoryBuffer [] = {
   { 0x05E00000, 0x00100000 },    // MCU
+  { 0x05F01000, 0x00001000 },    // ADB REBOOT "REASON"
   { 0x06DFF000, 0x00001000 },    // MAILBOX
   { 0x0740F000, 0x00001000 },    // MAILBOX
   { 0x3E000000, 0x02000000 }     // TEE OS


### PR DESCRIPTION
This allows the bootloader to user a reserved page to
read if the kernel requested we boot into fastboot
mode or normal bootup.

This allows users to reboot into fastboot mode w/o
having to modify jumpers on J15

This change requires the kernel to support the
communication of the reboot reason to the bootloader.

Would love any extra review or suggestions here to make sure I'm doing this right.

Cc: Vishal Bhoj vishal.bhoj@linaro.org
Cc: haojian.zhuang@linaro.org
Cc: guodong.xu@linaro.org
Signed-off-by: John Stultz john.stultz@linaro.org
