### PR TITLE
UEFI: Fastboot: Reduce HiKey max download size to avoid failures afte…

### DIFF
--- a/HisiPkg/HiKeyPkg/HiKey.dsc
+++ b/HisiPkg/HiKeyPkg/HiKey.dsc
@@ -344,8 +344,8 @@
 
   # Device path of block device on which Android Fastboot should flash partitions
   gHwTokenSpaceGuid.PcdAndroidFastbootNvmDevicePath|L"VenHw(b549f005-4bd4-4020-a0cb-06f42bda68c3)"
-  # Flash limit 500M/time, for memory concern
-  gHwTokenSpaceGuid.PcdArmFastbootFlashLimit|"524288000"
+  # Flash limit 128M/time, for memory concern
+  gHwTokenSpaceGuid.PcdArmFastbootFlashLimit|"134217728"
 
 ################################################################################
 #


### PR DESCRIPTION
…r chainloading from grub

This fixes/worksaround bug #215
https://bugs.96boards.org/show_bug.cgi?id=215

When fastboot.efi is chainloaded from grub, we end up with not
enough contiguous memory to allocate 500M chunks. Sadly we also
can't allocate 256M chunks either (which is a bit silly).

None the less, this patch provides a workaround, limiting the
max size to 128M chunks. This does not cause flashing to take
more time, but does spit out more output when flashing the
multiple chunks.

Signed-off-by: John Stultz john.stultz@linaro.org
